### PR TITLE
Use a dedicated database instead of the default postgres database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,23 +48,24 @@ stop:
 
 ## Start an interactive psql session
 sql:
-	psql -U postgres -h localhost -p 5432
+	psql -U postgres -h localhost -p 5432 -d plaid_payment_initiation
 
 ## Initialize the database (runs on first start)
 init-db:
-	@psql -U postgres -h localhost -p 5432 -tc \
+	@psql -U postgres -h localhost -p 5432 -c 'CREATE DATABASE plaid_payment_initiation' 2>/dev/null; \
+	psql -U postgres -h localhost -p 5432 -d plaid_payment_initiation -tc \
 	  "SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'users'" \
 	  | grep -q 1 \
 	  || (echo "Initializing database..." && \
-	      psql -U postgres -h localhost -p 5432 -f database/init/create.sql && \
+	      psql -U postgres -h localhost -p 5432 -d plaid_payment_initiation -f database/init/create.sql && \
 	      echo "Database initialized.")
 
 ## Drop and recreate all tables
 clear-db:
 	@echo "Clearing database..."
-	psql -U postgres -h localhost -p 5432 -c \
-	  "DROP TABLE IF EXISTS payment_status_updates, orders, accounts, users CASCADE;"
-	psql -U postgres -h localhost -p 5432 -f database/init/create.sql
+	psql -U postgres -h localhost -p 5432 -c 'DROP DATABASE IF EXISTS plaid_payment_initiation'
+	psql -U postgres -h localhost -p 5432 -c 'CREATE DATABASE plaid_payment_initiation'
+	psql -U postgres -h localhost -p 5432 -d plaid_payment_initiation -f database/init/create.sql
 	@echo "Database cleared and reinitialized."
 
 $(envfile):

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Don't want to use ngrok? As long as you serve the app with an endpoint that is p
 
 The database is a [PostgreSQL][postgres] instance running locally on port 5432.
 
-Username and password are configured in your `.env` file (defaults: `postgres` / `password`).
+The database name is `plaid_payment_initiation`. Username and password are configured in your `.env` file (defaults: `postgres` / `password`). Connect with `psql -U postgres -d plaid_payment_initiation`.
 
 To clear all the data in the database:
 

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -16,6 +16,7 @@ const { DB_PORT, DB_HOST_NAME, POSTGRES_USER, POSTGRES_PASSWORD } = process.env;
 const db = new Pool({
   host: DB_HOST_NAME,
   port: DB_PORT,
+  database: 'plaid_payment_initiation',
   user: POSTGRES_USER,
   password: POSTGRES_PASSWORD,
   max: 5,


### PR DESCRIPTION
## Problem

This issue was introduced by moving this app off of Docker.

The server's database pool config specified no `database` name, so it silently connected to PostgreSQL's built-in `postgres` database.

- **Any app or tool that also defaults to `postgres`** — including other Plaid sample apps like `pattern` — would have its schema clobbered by `make init-db` or `make clear-db`.
- `make clear-db` was especially dangerous: it dropped and recreated individual tables in the `postgres` database, potentially affecting anything else living there.
- This isn't specific to running multiple Plaid apps. Anyone with local PostgreSQL tooling, test databases, or other projects that default to the `postgres` database would be at risk.

This is the same issue fixed in plaid/pattern#353.

## Fix

- Add `database: 'plaid_payment_initiation'` to the Pool config in `server/db/index.js`
- Update `init-db` to `CREATE DATABASE plaid_payment_initiation` (safe no-op if it already exists) then run the init SQL against it
- Update `clear-db` to `DROP DATABASE IF EXISTS plaid_payment_initiation` then recreate it cleanly — scoped only to this app's database
- Update `sql` to connect to `plaid_payment_initiation` by default
- Update README to document the database name and connection command

## Test plan

- [ ] `make init-db` creates a `plaid_payment_initiation` database and initializes tables without touching any other database
- [ ] `make clear-db` drops and reinitializes only `plaid_payment_initiation`
- [ ] Server connects to `plaid_payment_initiation` on startup
- [ ] Existing data in `postgres` or other databases is unaffected
- [ ] `make sql` opens a psql session in `plaid_payment_initiation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: a4d3642a-6285-469d-8d16-c6adf355fe3f