### PR TITLE
Fix broken doc links in payment-initiation demo

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -34,7 +34,7 @@ VITE_PLAID_ENV=sandbox
 # When running in Production, you must use an https:// url.
 # You will need to configure this https:// redirect URI in the Plaid developer dashboard.
 # Instructions to create a self-signed certificate for localhost can be found at
-# https://github.com/plaid/pattern-europe/blob/master/README.md#testing-oauth
+# https://github.com/plaid/payment-initiation-pattern-app/blob/main/README.md#testing-with-oauth-redirect-uris-optional
 # If your system is not set up to run localhost with https://, you will be unable to test
 # the OAuth in Production and should leave the PLAID_PRODUCTION_REDIRECT_URI blank.
 

--- a/client/src/components/Landing.tsx
+++ b/client/src/components/Landing.tsx
@@ -28,7 +28,7 @@ const Landing: React.FC = () => {
         <a
           target="_blank"
           rel="noopener noreferrer"
-          href="https://plaid.com/docs/payment-initiation/user-onboarding-and-account-funding/"
+          href="https://plaid.com/docs/payment-initiation/"
           className="text-plaid-blue underline hover:text-plaid-blue/80"
         >
           account funding guide

--- a/server/routes/payments.js
+++ b/server/routes/payments.js
@@ -74,7 +74,7 @@ router.post(
 
     /**
      * Read more about the link/token/create endpoint:
-     * https://plaid.com/docs/api/tokens/#linktokencreate
+     * https://plaid.com/docs/api/link/#linktokencreate
      */
     const linkTokenCreateResponse = await plaid.linkTokenCreate({
       client_name: COMPANY_NAME,


### PR DESCRIPTION
Three stale links: the `/api/tokens/` reference (page merged into `/api/link/`), the removed `payment-initiation/user-onboarding-and-account-funding/` page (repointed to the Payment Initiation docs landing), and a copy-paste `pattern-europe` repo link in `.env.template` (repointed to this repo's own README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)