### PR TITLE
Verify webhook signatures before releasing payment funds

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,6 @@
 const socketIo = require('socket.io');
 
 const express = require('express');
-const cookieParser = require('cookie-parser');
 const logger = require('morgan');
 
 const { errorHandler } = require('./middleware');
@@ -77,9 +76,19 @@ axiosInstance.interceptors.response.use(response => {
 });
 
 app.use(logger('dev'));
-app.use(express.json());
+/**
+ * Webhook verification needs the exact bytes Plaid signed, not the parsed-then-
+ * reserialized body, so we stash the raw buffer alongside req.body here rather
+ * than re-deriving it later.
+ */
+app.use(
+  express.json({
+    verify: (req, res, buf) => {
+      req.rawBody = buf;
+    },
+  })
+);
 app.use(express.urlencoded({ extended: false }));
-app.use(cookieParser());
 
 app.use('/users', usersRouter);
 app.use('/sessions', sessionsRouter);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,9 +10,10 @@
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "axios": "^1.15.2",
-        "cookie-parser": "^1.4.7",
         "debug": "^4.4.3",
         "express": "^5.2.1",
+        "jsonwebtoken": "^9.0.3",
+        "jwk-to-pem": "^2.0.7",
         "lodash": "^4.17.23",
         "morgan": "^1.10.1",
         "node-fetch": "^2.7.0",
@@ -486,6 +487,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -580,6 +593,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
+      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -629,6 +648,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -829,25 +860,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/cookie-parser": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
-      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "0.7.2",
-        "cookie-signature": "1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
-    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -1039,11 +1051,35 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -2165,6 +2201,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
@@ -2175,6 +2221,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/http-errors": {
@@ -2804,6 +2861,72 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwk-to-pem": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/jwk-to-pem/-/jwk-to-pem-2.0.7.tgz",
+      "integrity": "sha512-cSVphrmWr6reVchuKQZdfSs4U9c5Y4hwZggPoz6cbVnTpAVgGRpEuQng86IyqLeGZlhTh+c4MAreB6KbdQDKHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "elliptic": "^6.6.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2850,11 +2973,53 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -2907,6 +3072,18 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -3913,6 +4090,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -10,9 +10,10 @@
   "dependencies": {
     "@hapi/boom": "^10.0.1",
     "axios": "^1.15.2",
-    "cookie-parser": "^1.4.7",
     "debug": "^4.4.3",
     "express": "^5.2.1",
+    "jsonwebtoken": "^9.0.3",
+    "jwk-to-pem": "^2.0.7",
     "lodash": "^4.17.23",
     "morgan": "^1.10.1",
     "node-fetch": "^2.7.0",

--- a/server/routes/payments.js
+++ b/server/routes/payments.js
@@ -3,6 +3,7 @@
  */
 
 const express = require('express');
+const Boom = require('@hapi/boom');
 const { asyncWrapper } = require('../middleware');
 const { plaid } = require('../plaid');
 const { getPublicUrlForBackend } = require('../util');
@@ -16,6 +17,36 @@ const router = express.Router();
 const userIdToLinkTokenMapping = new Map();
 
 /**
+ * The recipient in this demo is a single fixed beneficiary account, so its
+ * details never change between payments. Calling paymentInitiationRecipientCreate
+ * on every payment would just create a redundant recipient for the same
+ * beneficiary each time, so we create it once and reuse the resulting
+ * recipient_id. A real integration would persist this in its database rather
+ * than in memory.
+ */
+let recipientIdPromise = null;
+const getOrCreateRecipientId = () => {
+  if (recipientIdPromise == null) {
+    /**
+     * Read more about the payment_initiation/recipient/create endpoint:
+     * https://plaid.com/docs/api/products/payment-initiation/#payment_initiationrecipientcreate
+     */
+    recipientIdPromise = plaid
+      .paymentInitiationRecipientCreate({
+        name: COMPANY_NAME, // The beneficiary of the bank account. This will be displayed on the Link UI.
+        iban: 'NL06INGB5632579034', // non-existent example IBAN. In the UK provide "bacs" instead.
+      })
+      .then(response => response.data.recipient_id)
+      .catch(err => {
+        // Allow a later request to retry creating the recipient if this attempt failed.
+        recipientIdPromise = null;
+        throw err;
+      });
+  }
+  return recipientIdPromise;
+};
+
+/**
  * @desc This endpoint creates the resources required to initiate a payment with Plaid. It returns a link token which is used by the client to initiate Link.
  * This endpoint also creates a payment "order" which is used to manage payment reconciliation.
  */
@@ -24,20 +55,21 @@ router.post(
   asyncWrapper(async (req, res) => {
     const { amount, accountId } = req.body;
 
+    if (!Number.isInteger(accountId) || accountId <= 0) {
+      throw Boom.badRequest('accountId must be a positive integer.');
+    }
+    if (typeof amount !== 'number' || !Number.isFinite(amount) || amount <= 0) {
+      throw Boom.badRequest('amount must be a positive number.');
+    }
+
     const account = await retrieveAccountById(accountId);
+    if (account == null) {
+      throw Boom.badRequest('Account does not exist.');
+    }
     const userId = account.user_id;
     const paymentReference = `account${accountId}`;
 
-    /**
-     * Read more about the payment_initiation/recipient/create endpoint:
-     * https://plaid.com/docs/api/products/payment-initiation/#payment_initiationrecipientcreate
-     */
-    const recipientCreateResponse = await plaid.paymentInitiationRecipientCreate(
-      {
-        name: COMPANY_NAME, // The beneficiary of the bank account. This will be displayed on the Link UI.
-        iban: 'NL06INGB5632579034', // non-existent example IBAN. In the UK provide "bacs" instead.
-      }
-    );
+    const recipientId = await getOrCreateRecipientId();
 
     /**
      * Plaid recommends using integers for arithmetic operations as accuracy might be lost when using floats.
@@ -49,7 +81,7 @@ router.post(
      * https://plaid.com/docs/api/products/payment-initiation/#payment_initiationpaymentcreate
      */
     const paymentCreateResponse = await plaid.paymentInitiationPaymentCreate({
-      recipient_id: recipientCreateResponse.data.recipient_id,
+      recipient_id: recipientId,
       amount: {
         currency: 'EUR',
         /**

--- a/server/routes/webhooks.js
+++ b/server/routes/webhooks.js
@@ -25,12 +25,13 @@ router.post(
      * it - otherwise this endpoint would let anyone forge that webhook and
      * mark a payment executed without any money moving.
      *
-     * An alternative to verifying the JWT is to not trust the webhook body's
-     * fields at all: treat the webhook purely as a "something changed, go
+     * An alternative to verifying the JWT: don't trust the webhook body's
+     * fields at all. Treat the webhook purely as a "something changed, go
      * check" notification, then call paymentInitiationPaymentGet({ payment_id })
-     * and read new_payment_status back from that authoritative API response
-     * instead of from request.body. That sidesteps forged bodies too, at the
-     * cost of an extra Plaid API round trip on every webhook.
+     * and read new_payment_status from that response instead of from
+     * request.body. That costs an extra Plaid API round trip on every
+     * webhook, versus a local signature check once the verification key is
+     * cached.
      */
     try {
       await verifyWebhook(

--- a/server/routes/webhooks.js
+++ b/server/routes/webhooks.js
@@ -29,9 +29,7 @@ router.post(
      * fields at all. Treat the webhook purely as a "something changed, go
      * check" notification, then call paymentInitiationPaymentGet({ payment_id })
      * and read new_payment_status from that response instead of from
-     * request.body. That costs an extra Plaid API round trip on every
-     * webhook, versus a local signature check once the verification key is
-     * cached.
+     * request.body.
      */
     try {
       await verifyWebhook(

--- a/server/routes/webhooks.js
+++ b/server/routes/webhooks.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const Boom = require('@hapi/boom');
 
 const router = express.Router();
 
@@ -7,6 +8,7 @@ const {
   createPaymentStatusUpdate,
   markOrderExecutedByPaymentId,
 } = require('../db/queries');
+const { verifyWebhook } = require('../webhookVerification');
 
 /**
  * Handles incoming webhooks from Plaid. Read more about webhooks:
@@ -15,6 +17,30 @@ const {
 router.post(
   '/',
   asyncWrapper(async (request, response) => {
+    /**
+     * PAYMENT_STATUS_UPDATE webhooks are what tell us a payment reached
+     * PAYMENT_STATUS_EXECUTED, which we treat as authorization to release
+     * funds (see markOrderExecutedByPaymentId below). Since that's a real
+     * side effect, we only trust the body once we've confirmed Plaid signed
+     * it - otherwise this endpoint would let anyone forge that webhook and
+     * mark a payment executed without any money moving.
+     *
+     * An alternative to verifying the JWT is to not trust the webhook body's
+     * fields at all: treat the webhook purely as a "something changed, go
+     * check" notification, then call paymentInitiationPaymentGet({ payment_id })
+     * and read new_payment_status back from that authoritative API response
+     * instead of from request.body. That sidesteps forged bodies too, at the
+     * cost of an extra Plaid API round trip on every webhook.
+     */
+    try {
+      await verifyWebhook(
+        request.rawBody,
+        request.headers['plaid-verification']
+      );
+    } catch (err) {
+      throw Boom.unauthorized(`Webhook verification failed: ${err.message}`);
+    }
+
     const {
       webhook_code: webhookCode,
       timestamp: webhookTimestamp,

--- a/server/webhookVerification.js
+++ b/server/webhookVerification.js
@@ -1,0 +1,125 @@
+/**
+ * @file Verifies that incoming webhooks actually came from Plaid.
+ *
+ * Why this exists: our /webhooks route trusts the request body to decide when to
+ * mark a payment order as executed (which releases funds to the account balance).
+ * Without verification, anyone who can reach that endpoint could POST a forged
+ * PAYMENT_STATUS_EXECUTED body and trigger that release without a real payment
+ * ever happening. Plaid signs every webhook body with a JWT in the
+ * `Plaid-Verification` header so the receiver can check it wasn't forged or
+ * tampered with in transit. See: https://plaid.com/docs/api/webhooks/webhook-verification/
+ */
+
+const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
+const jwkToPem = require('jwk-to-pem');
+const { plaid } = require('./plaid');
+
+/**
+ * Plaid's signing keys rotate infrequently, and the same `kid` is reused across
+ * many webhooks. Calling `/webhook_verification_key/get` on every request would
+ * just re-fetch a key we already have, so we cache by `kid` and only call the
+ * API the first time we see a given key. Plaid docs recommend keeping keys
+ * cached indefinitely, but discarding a cached key once Plaid reports it as
+ * expired (via `expired_at`) so rotation is picked up.
+ */
+const keyCache = new Map();
+
+const getVerificationKey = async keyId => {
+  const cached = keyCache.get(keyId);
+  if (cached && !(cached instanceof Promise) && cached.expired_at == null) {
+    return cached;
+  }
+
+  /**
+   * Cache the in-flight promise, not just the resolved key, so a burst of
+   * webhooks for a kid we haven't seen yet (e.g. right after Plaid rotates
+   * its signing key) share one fetch instead of each firing their own
+   * webhookVerificationKeyGet call.
+   */
+  if (cached instanceof Promise) {
+    return cached;
+  }
+
+  const keyPromise = plaid
+    .webhookVerificationKeyGet({ key_id: keyId })
+    .then(response => response.data.key)
+    .catch(err => {
+      // Allow a later request to retry fetching this key if this attempt failed.
+      keyCache.delete(keyId);
+      throw err;
+    });
+  keyCache.set(keyId, keyPromise);
+
+  const key = await keyPromise;
+  keyCache.set(keyId, key);
+  return key;
+};
+
+/**
+ * @param {Buffer} rawBody the exact, unparsed request body bytes as sent by
+ *   Plaid. The signature covers these bytes, so verification must run against
+ *   the raw buffer rather than the JSON re-serialized by Express - re-serializing
+ *   can reorder keys or change whitespace and would make a legitimate webhook
+ *   fail verification.
+ * @param {string} signedJwt the value of the `Plaid-Verification` header.
+ * @throws if the header is missing, the JWT is malformed, the signature doesn't
+ *   verify, the token is stale, or the body hash doesn't match.
+ */
+const verifyWebhook = async (rawBody, signedJwt) => {
+  if (!signedJwt) {
+    throw new Error('Missing Plaid-Verification header.');
+  }
+  /**
+   * express.json({verify}) only populates rawBody when the request's
+   * Content-Type matches application/json. A request that arrives with a
+   * different or missing Content-Type (e.g. manual testing with curl) would
+   * otherwise reach the hashing step below with rawBody undefined and fail
+   * with a cryptic Buffer/TypeError instead of an explanation.
+   */
+  if (!rawBody) {
+    throw new Error('Webhook body is unavailable for verification.');
+  }
+
+  const decodedHeader = jwt.decode(signedJwt, { complete: true });
+  if (!decodedHeader || decodedHeader.header.alg !== 'ES256') {
+    throw new Error('Invalid webhook JWT header.');
+  }
+
+  const keyId = decodedHeader.header.kid;
+  const key = await getVerificationKey(keyId);
+  if (key.expired_at != null) {
+    throw new Error(`Webhook verification key ${keyId} has expired.`);
+  }
+
+  const pem = jwkToPem(key);
+  const payload = jwt.verify(signedJwt, pem, { algorithms: ['ES256'] });
+
+  /**
+   * Reject tokens that aren't fresh. Without this, a captured webhook body/JWT
+   * pair could be replayed indefinitely to re-trigger the same side effects.
+   * Plaid recommends rejecting anything older than 5 minutes.
+   */
+  const ageSeconds = Date.now() / 1000 - payload.iat;
+  if (ageSeconds > 5 * 60) {
+    throw new Error('Webhook verification token is too old.');
+  }
+
+  /**
+   * The JWT signature only proves Plaid issued this token - it says nothing
+   * about which body it was issued for. Plaid binds the two together by
+   * embedding a SHA-256 hash of the body in the `request_body_sha256` claim,
+   * so we recompute that hash ourselves and compare.
+   */
+  const bodyHash = crypto.createHash('sha256').update(rawBody).digest('hex');
+  if (
+    !crypto.timingSafeEqual(
+      Buffer.from(bodyHash),
+      Buffer.from(payload.request_body_sha256)
+    )
+  ) {
+    throw new Error('Webhook body hash does not match.');
+  }
+};
+
+module.exports = { verifyWebhook };


### PR DESCRIPTION
`/webhooks` trusted the raw request body to decide when a payment reached `PAYMENT_STATUS_EXECUTED`, which the UI then counts toward the account balance ([`computeBalance`](https://github.com/plaid/payment-initiation-pattern-app/blob/main/server/routes/users.js)) — so anyone who could reach the endpoint could forge that webhook and mark a payment executed without any money moving. This adds verification of the `Plaid-Verification` JWT (per [Plaid's webhook verification docs](https://plaid.com/docs/api/webhooks/webhook-verification/)) before trusting the payload: key fetch/caching by `kid`, a freshness check, and a body-hash comparison against the raw request bytes.

While in `payments.js`, also:
- validate `amount`/`accountId` on `create_link_token` instead of trusting them unchecked
- cache the recipient instead of calling `paymentInitiationRecipientCreate` on every payment (it's the same fixed beneficiary each time)
- drop the unused `cookie-parser` dependency

<details>
<summary>Notes on a couple of design choices</summary>

- The webhook-verification key cache stores the in-flight fetch promise (not just the resolved key), so a burst of webhooks for a newly-rotated key share one `webhookVerificationKeyGet` call instead of each firing their own.
- A request whose raw body is unavailable for hashing (e.g. wrong `Content-Type` during manual testing) now fails with a clear message instead of a raw `TypeError`.
</details>