### PR TITLE
Upgrade react-plaid-link to 5.0.0

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,7 +17,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-plaid-link": "^4.1.1",
+        "react-plaid-link": "^5.0.0",
         "react-router-dom": "^5.3.4",
         "react-router-hash-link": "^2.4.3",
         "react-syntax-highlighter": "^16.1.1",
@@ -3240,9 +3240,9 @@
       "license": "MIT"
     },
     "node_modules/react-plaid-link": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-4.1.1.tgz",
-      "integrity": "sha512-xzAYWQIT/gk+u6lwFAMEZ20f9+AUsCwVyfm64/iudMsyuWANta4wm3Jb7N+APSwuKIR9VUlTkYDhPjLamIGcPA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-plaid-link/-/react-plaid-link-5.0.0.tgz",
+      "integrity": "sha512-DZ/6C7hf+xhEIG9ElCqjk1lty/z+y+wQuV/A29EUx4fxiPLPe7CXN811C3MrCzI7grV45LD7NRS0Do0ma8KIBg==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-plaid-link": "^4.1.1",
+    "react-plaid-link": "^5.0.0",
     "react-router-dom": "^5.3.4",
     "react-router-hash-link": "^2.4.3",
     "react-syntax-highlighter": "^16.1.1",


### PR DESCRIPTION
5.0.0 corrects the public TypeScript definitions to match the Link Web SDK, so this is a types-only upgrade — runtime behavior is unchanged. No source changes were needed here: the `Link` component already types its callback as `PlaidLinkOnSuccess` and never exchanges the public token, since `payment_initiation` has no access token to swap it for.